### PR TITLE
feat: improve install scripts

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -40,5 +40,6 @@ if [[ "${#BASH_SOURCE[@]}" -eq 1 ]]; then
     script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
     # shellcheck source=./install
     source "${script_dir}/install"
+    setup_colors
     bootstrap "$@"
 fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,35 +7,38 @@ IFS=$'\n\t'
 
 bootstrap () {
     cd "$(dirname "$0")/.."
-    echo "==> script/bootstrap…"
+    msg_header "==> script/bootstrap…"
 
     bootstrap_xcode
     bootstrap_homebrew
 }
 
 bootstrap_xcode () {
-    echo "==> Looking for Command Line Tools…"
+    msg_info "==> Looking for Command Line Tools…"
     xcode-select --print-path >/dev/null 2>&1 || {
-        echo "==> Installing Command Line Tools…"
+        msg_info "==> Installing Command Line Tools…"
         xcode-select --install
     }
 }
 
 bootstrap_homebrew () {
     if ! [ -x "$(command -v brew)" ]; then
-        echo "==> Installing Homebrew…"
+        msg_info "==> Installing Homebrew…"
         /usr/bin/env bash -c \
             "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
     fi
     if [ -f "Brewfile" ] && [ "$(uname -s)" = "Darwin" ]; then
-        echo "==> Checking Homebrew dependencies…"
+        msg_info "==> Checking Homebrew dependencies…"
         brew bundle check >/dev/null 2>&1  || {
-            echo "==> Installing Homebrew dependencies…"
+            msg_info "==> Installing Homebrew dependencies…"
             brew bundle --no-upgrade
         }
     fi
 }
 
 if [[ "${#BASH_SOURCE[@]}" -eq 1 ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+    # shellcheck source=./install
+    source "${script_dir}/install"
     bootstrap "$@"
 fi

--- a/script/install
+++ b/script/install
@@ -70,6 +70,10 @@ setup () {
 
 setup_colors
 
-if [[ "${0}" == "/bin/bash" ]] || [[ "${#BASH_SOURCE[@]}" -eq 1 ]]; then
+if \
+  [ "$0##*/}" == "bash" ] || \
+  [ "${0}" == "/dev/fd/11" ] || \
+  [ "${#BASH_SOURCE[@]}" -eq 1 ]
+then
     install "$@"
 fi

--- a/script/install
+++ b/script/install
@@ -68,12 +68,11 @@ setup () {
     script/setup
 }
 
-setup_colors
-
 if \
   [ "$0##*/}" == "bash" ] || \
   [ "${0}" == "/dev/fd/11" ] || \
   [ "${#BASH_SOURCE[@]}" -eq 1 ]
 then
+    setup_colors
     install "$@"
 fi

--- a/script/install
+++ b/script/install
@@ -12,7 +12,7 @@ SRC_DIR="${HOME}/src/github.com/jackboberg"
 DOT_DIR="${SRC_DIR}/dotfiles"
 
 install () {
-    msg_info "==> script/install…"
+    msg_header "==> script/install…"
     install_xcode
     get_dotfiles
     setup
@@ -36,6 +36,10 @@ msg () {
 }
 
 msg_info () {
+    msg "${PURPLE}${1-}${NOFORMAT}"
+}
+
+msg_header () {
     msg "${BLUE}${1-}${NOFORMAT}"
 }
 

--- a/script/install
+++ b/script/install
@@ -5,29 +5,52 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+trap cleanup SIGINT SIGTERM ERR EXIT
+
 REPO="https://github.com/jackboberg/dotfiles.git"
 SRC_DIR="${HOME}/src/github.com/jackboberg"
 DOT_DIR="${SRC_DIR}/dotfiles"
 
 install () {
-    echo "==> script/install…"
+    msg_info "==> script/install…"
     install_xcode
     get_dotfiles
     setup
 }
 
+cleanup () {
+    trap - SIGINT SIGTERM ERR EXIT
+    msg_info "==> Cleaning up…"
+}
+
+setup_colors () {
+    if [[ -t 2 ]] && [[ -z "${NO_COLOR-}" ]] && [[ "${TERM-}" != "dumb" ]]; then
+        NOFORMAT='\033[0m' RED='\033[0;31m' GREEN='\033[0;32m' ORANGE='\033[0;33m' BLUE='\033[0;34m' PURPLE='\033[0;35m' CYAN='\033[0;36m' YELLOW='\033[1;33m'
+    else
+      NOFORMAT='' RED='' GREEN='' ORANGE='' BLUE='' PURPLE='' CYAN='' YELLOW=''
+    fi
+}
+
+msg () {
+    echo >&2 -e "${1-}"
+}
+
+msg_info () {
+    msg "${BLUE}${1-}${NOFORMAT}"
+}
+
 install_xcode () {
-    echo "==> Looking for Command Line Tools…"
+    msg_info "==> Looking for Command Line Tools…"
     xcode-select --print-path >/dev/null 2>&1 || {
-        echo "==> Installing Command Line Tools…"
+        msg_info "==> Installing Command Line Tools…"
         xcode-select --install
     }
 }
 
 get_dotfiles () {
-    echo "==> Getting dotfiles…"
+    msg_info "==> Getting dotfiles…"
     if [ -d "$DOT_DIR" ]; then
-        echo "==> $DOT_DIR exists…"
+        msg_info "==> $DOT_DIR exists…"
         exit 1
     fi
 
@@ -36,9 +59,13 @@ get_dotfiles () {
 }
 
 setup () {
-    echo "==> Setting up dotfiles…"
+    msg_info "==> Setting up dotfiles…"
     cd $DOT_DIR
     script/setup
 }
 
-install "$@"
+setup_colors
+
+if [[ "${0}" == "/bin/bash" ]] || [[ "${#BASH_SOURCE[@]}" -eq 1 ]]; then
+    install "$@"
+fi

--- a/script/install
+++ b/script/install
@@ -5,8 +5,6 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-trap cleanup SIGINT SIGTERM ERR EXIT
-
 REPO="https://github.com/jackboberg/dotfiles.git"
 SRC_DIR="${HOME}/src/github.com/jackboberg"
 DOT_DIR="${SRC_DIR}/dotfiles"
@@ -16,11 +14,6 @@ install () {
     install_xcode
     get_dotfiles
     setup
-}
-
-cleanup () {
-    trap - SIGINT SIGTERM ERR EXIT
-    msg_info "==> Cleaning up…"
 }
 
 setup_colors () {

--- a/script/setup
+++ b/script/setup
@@ -79,5 +79,6 @@ if [[ "${#BASH_SOURCE[@]}" -eq 1 ]]; then
     script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
     # shellcheck source=./install
     source "${script_dir}/install"
+    setup_colors
     setup "$@"
 fi

--- a/script/setup
+++ b/script/setup
@@ -8,8 +8,8 @@ IFS=$'\n\t'
 setup () {
     cd "$(dirname "$0")/.."
     script/bootstrap
+    msg_header "==> script/setup…"
 
-    echo "==> script/setup…"
     setup_rc
     setup_secure_files
     setup_iterm
@@ -18,7 +18,7 @@ setup () {
 }
 
 setup_rc () {
-    echo "==> Setting up RC files…"
+    msg_info "==> Setting up RC files…"
     local dir
 
     # Set this repo as the source directory.
@@ -29,7 +29,7 @@ setup_rc () {
 }
 
 setup_secure_files () {
-    echo "==> Setting up secure files…"
+    msg_info "==> Setting up secure files…"
     local icloud_dir
     icloud_dir="${HOME}/Library/Mobile\ Documents/com\~apple\~CloudDocs"
 
@@ -41,7 +41,7 @@ setup_secure_files () {
 }
 
 setup_iterm () {
-    echo "==> Setting up iTerm2 preferences…"
+    msg_info "==> Setting up iTerm2 preferences…"
     local dir
     local plist
     plist="com.googlecode.iterm2.plist"
@@ -55,7 +55,7 @@ setup_iterm () {
 }
 
 setup_emacs () {
-    echo "==> Setting up Emacs…"
+    msg_info "==> Setting up Emacs…"
     ghq get plexus/chemacs
     $(ghq list -p plexus/chemacs)/install.sh
 
@@ -67,7 +67,7 @@ setup_emacs () {
 }
 
 setup_asdf () {
-    echo "==> Setting up global tools…"
+    msg_info "==> Setting up global tools…"
     less asdf-plugins | xargs -n 1 asdf plugin add
 
     ${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring
@@ -76,5 +76,8 @@ setup_asdf () {
 }
 
 if [[ "${#BASH_SOURCE[@]}" -eq 1 ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+    # shellcheck source=./install
+    source "${script_dir}/install"
     setup "$@"
 fi

--- a/script/update
+++ b/script/update
@@ -15,5 +15,6 @@ if [[ "${#BASH_SOURCE[@]}" -eq 1 ]]; then
     script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
     # shellcheck source=./install
     source "${script_dir}/install"
+    setup_colors
     update "$@"
 fi

--- a/script/update
+++ b/script/update
@@ -8,10 +8,12 @@ IFS=$'\n\t'
 update () {
     cd "$(dirname "$0")/.."
     script/bootstrap
-
-    echo "==> script/update…"
+    header "==> script/update…"
 }
 
 if [[ "${#BASH_SOURCE[@]}" -eq 1 ]]; then
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+    # shellcheck source=./install
+    source "${script_dir}/install"
     update "$@"
 fi


### PR DESCRIPTION
Makes `install` easier to use in different contexts, and allows for added parameters (someday, maybe)..

```
/usr/bin/env bash -c "$(curl -fsSL $REMOTE_URL)"
/bin/bash <(curl -fsSL $REMOTE_URL) --buzz boop
./install --local true
```

..and allows sourcing `install` in other scripts to reuse utility functions (eg: friendly colored messages).